### PR TITLE
 File read error integration

### DIFF
--- a/07-behaviour_error_handling/internal/errors/errortypes.go
+++ b/07-behaviour_error_handling/internal/errors/errortypes.go
@@ -26,3 +26,21 @@ func IsDataUnreacheable(err error) bool {
 	_, ok := err.(*dataUnreacheable)
 	return ok
 }
+
+type fileReadError struct {
+	error
+}
+
+// WrapFileReadError returns an error which wraps err that satisfies
+// IsFileReadError
+func WrapFileReadError(err error, format string, args ...interface{}) error {
+	return &fileReadError{errors.Wrapf(err, format, args ...)}
+}
+
+// IsFileReadError reports whether err was created with FileReadErrorf() or
+// NewIsFileReadError()
+func IsFileReadError(err error) bool {
+	err = errors.Cause(err)
+	_, ok := err.(*fileReadError)
+	return ok
+}

--- a/07-behaviour_error_handling/internal/storage/csv/repository.go
+++ b/07-behaviour_error_handling/internal/storage/csv/repository.go
@@ -7,6 +7,11 @@ import (
 	"strings"
 
 	beerscli "github.com/CodelyTV/golang-introduction/07-behaviour_error_handling/internal"
+	"github.com/CodelyTV/golang-introduction/07-behaviour_error_handling/internal/errors"
+)
+
+const(
+	beersFile = "07-behaviour_error_handling/data/beers.csv"
 )
 
 type repository struct {
@@ -19,7 +24,10 @@ func NewRepository() beerscli.BeerRepo {
 
 // GetBeers fetch beers data from csv
 func (r *repository) GetBeers() ([]beerscli.Beer, error) {
-	f, _ := os.Open("07-behaviour_error_handling/data/beers.csv")
+	f, err := os.Open(beersFile)
+	if err != nil {
+		return nil, errors.WrapFileReadError(err, "error getting the file %s", beersFile)
+	}
 	reader := bufio.NewReader(f)
 
 	var beers []beerscli.Beer
@@ -27,7 +35,10 @@ func (r *repository) GetBeers() ([]beerscli.Beer, error) {
 	for line := readLine(reader); line != nil; line = readLine(reader) {
 		values := strings.Split(string(line), ",")
 
-		productID, _ := strconv.Atoi(values[0])
+		productID, err := strconv.Atoi(values[0])
+		if err != nil {
+			return nil, errors.WrapFileReadError(err, "error getting reading the file %s", beersFile)
+		}
 
 		beer := beerscli.NewBeer(
 			productID,


### PR DESCRIPTION
Changes in 07-behaviour_error_handling based on exercise instructions:

* A new error type has been added to `internal/errors/errortypes.go`
* Its usage is located in `internal/storage/csv/repository.go` when an error occurs reading the CSV file
* In addition, the CSV beers file in `internal/storage/csv/repository.go` is now a constant